### PR TITLE
fix: Update SCSS processing and env var access for Hugo build

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,7 +17,7 @@
   {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
-  {{ $styles := resources.Get "scss/style.scss" | toCSS | minify }}
+  {{ $styles := resources.Get "scss/style.scss" | resources.Sass (dict "outputStyle" "compressed") | resources.Minify }}
   <link rel="stylesheet" href="{{ $styles.Permalink }}" media="screen">
 
   {{ "<!--Favicon-->" | safeHTML }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -53,7 +53,7 @@
   {{ template "_internal/google_analytics.html" . }}
 
   {{/* ─────── 3) Chargement des CSS : Vex, Bootstrap, puis ton CSS perso ─────── */}}
-  {{ $style := resources.Get "scss/style.scss" | resources.ToCSS (dict "outputStyle" "compressed") | resources.Minify | resources.Fingerprint }}
+  {{ $style := resources.Get "scss/style.scss" | resources.Sass (dict "outputStyle" "compressed") | resources.Minify | resources.Fingerprint }}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
@@ -160,11 +160,11 @@
       let supabase_client = null;
 
       // Initialize Supabase Client
-      const SUPABASE_URL = '{{ getenv "SUPABASE_URL" }}';
-      const SUPABASE_ANON_KEY = '{{ getenv "SUPABASE_ANON_KEY_PUBLIC" }}';
+      const SUPABASE_URL = '{{ getenv "HUGO_SUPABASE_URL" }}';
+      const SUPABASE_ANON_KEY = '{{ getenv "HUGO_SUPABASE_ANON_KEY_PUBLIC" }}';
 
       if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-        console.error('Supabase URL or Anon Key is missing. Check Netlify environment variables (SUPABASE_URL, SUPABASE_ANON_KEY_PUBLIC) and Hugo build logs.');
+        console.error('Supabase URL or Anon Key is missing. Check Netlify environment variables (HUGO_SUPABASE_URL, HUGO_SUPABASE_ANON_KEY_PUBLIC) and Hugo build logs.');
         const reviewsDisplay = document.getElementById('product-reviews-display');
         if(reviewsDisplay) reviewsDisplay.innerHTML = '<p class="text-danger">Review and submission system is currently unavailable due to configuration error.</p>';
         // Optionally disable review form


### PR DESCRIPTION
This commit addresses Hugo build failures by:

1.  **Replacing Deprecated `resources.ToCSS`:**
    *   Updated `layouts/products/single.html` and `layouts/partials/head.html` to use `resources.Sass` instead of the deprecated `resources.ToCSS` for SCSS compilation. This aligns with current Hugo best practices.

2.  **Adjusting `getenv` Usage for Security Policy:**
    *   Modified `layouts/products/single.html` to fetch Supabase configuration by calling `getenv` with `HUGO_` prefixed environment variable names (i.e., `HUGO_SUPABASE_URL` and `HUGO_SUPABASE_ANON_KEY_PUBLIC`).
    *   This change is necessary to comply with Hugo's default security policy, which restricts `getenv` access to variables with specific prefixes (like `HUGO_`).
    *   The client-side JavaScript error message for missing credentials has also been updated to reflect these new variable names.

**Action Required by You:**
You must rename the corresponding environment variables in your Netlify site settings to `HUGO_SUPABASE_URL` and `HUGO_SUPABASE_ANON_KEY_PUBLIC` for the Supabase integration to function correctly.