### PR TITLE
fix: Improve robustness of SCSS processing in templates

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,8 +17,13 @@
   {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
-  {{ $styles := resources.Get "scss/style.scss" | resources.Sass (dict "outputStyle" "compressed") | resources.Minify }}
-  <link rel="stylesheet" href="{{ $styles.Permalink }}" media="screen">
+  {{ $scssResource := resources.Get "scss/style.scss" }}
+  {{ if $scssResource }}
+    {{ $styles := $scssResource | resources.Sass (dict "outputStyle" "compressed") | resources.Minify }}
+    <link rel="stylesheet" href="{{ $styles.Permalink }}" media="screen">
+  {{ else }}
+    {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/partials/head.html. Main stylesheet will be missing." }}
+  {{ end }}
 
   {{ "<!--Favicon-->" | safeHTML }}
   <link rel="shortcut icon" href="{{ `images/favicon.png` | absURL }} " type="image/x-icon">

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -53,8 +53,13 @@
   {{ template "_internal/google_analytics.html" . }}
 
   {{/* ─────── 3) Chargement des CSS : Vex, Bootstrap, puis ton CSS perso ─────── */}}
-  {{ $style := resources.Get "scss/style.scss" | resources.Sass (dict "outputStyle" "compressed") | resources.Minify | resources.Fingerprint }}
-  <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
+  {{ $scssResource := resources.Get "scss/style.scss" }}
+  {{ if $scssResource }}
+    {{ $style := $scssResource | resources.Sass (dict "outputStyle" "compressed") | resources.Minify | resources.Fingerprint }}
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
+  {{ else }}
+    {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/products/single.html. Main stylesheet will be missing for product pages." }}
+  {{ end }}
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
         integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT"


### PR DESCRIPTION
This commit addresses a Hugo build error ("can't evaluate field Sass in type interface {}") by making the SCSS processing logic more robust in the relevant templates.

1.  **`layouts/partials/head.html` Updated:**
    *   Modified the SCSS pipeline to first use `resources.Get "scss/style.scss"` to fetch the resource.
    *   Added an `if` condition to check if the resource was successfully found before attempting to process it with `resources.Sass`, `resources.Minify`, etc.
    *   If the resource is not found, a `warnf` message is logged to the build output, and the stylesheet link is omitted, preventing the build from failing due to this specific error.

2.  **`layouts/products/single.html` Updated:**
    *   Applied the same robust SCSS processing pattern as in `head.html`.
    *   It now also checks if `assets/scss/style.scss` is found before processing, logs a warning if not, and omits the stylesheet link accordingly.

These changes aim to prevent the build from failing if the SCSS file cannot be accessed by `resources.Get` for any reason, and provide more informative warnings in the build log.