### PR TITLE
fix: Enhance robustness of SCSS processing pipelines

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,10 +17,21 @@
   {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
-  {{ $scssResource := resources.Get "scss/style.scss" }}
-  {{ if $scssResource }}
-    {{ $styles := $scssResource | resources.Sass (dict "outputStyle" "compressed") | resources.Minify }}
-    <link rel="stylesheet" href="{{ $styles.Permalink }}" media="screen">
+  {{ $scssFile := "scss/style.scss" }}
+  {{ $scssOptions := (dict "outputStyle" "compressed") }}
+  {{ $stylesheet := "" }} {{/* Initialize $stylesheet */}}
+
+  {{ $originalResource := resources.Get $scssFile }}
+
+  {{ if $originalResource }}
+    {{ if ne $originalResource.Content "" }} {{/* Check if content is not empty */}}
+      {{ $processedStyles := resources.Sass $originalResource $scssOptions }}
+      {{ $minifiedStyles := $processedStyles | resources.Minify }}
+      {{ $stylesheet = $minifiedStyles }}
+      <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
+    {{ else }}
+      {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/partials/head.html." }}
+    {{ end }}
   {{ else }}
     {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/partials/head.html. Main stylesheet will be missing." }}
   {{ end }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -53,10 +53,22 @@
   {{ template "_internal/google_analytics.html" . }}
 
   {{/* ─────── 3) Chargement des CSS : Vex, Bootstrap, puis ton CSS perso ─────── */}}
-  {{ $scssResource := resources.Get "scss/style.scss" }}
-  {{ if $scssResource }}
-    {{ $style := $scssResource | resources.Sass (dict "outputStyle" "compressed") | resources.Minify | resources.Fingerprint }}
-    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
+  {{ $scssFile := "scss/style.scss" }}
+  {{ $scssOptions := (dict "outputStyle" "compressed") }}
+  {{ $stylesheet := "" }} {{/* Initialize $stylesheet */}}
+
+  {{ $originalResource := resources.Get $scssFile }}
+
+  {{ if $originalResource }}
+    {{ if ne $originalResource.Content "" }} {{/* Check if content is not empty */}}
+      {{ $processedStyles := resources.Sass $originalResource $scssOptions }}
+      {{ $minifiedStyles := $processedStyles | resources.Minify }}
+      {{ $fingerprintedStyles := $minifiedStyles | resources.Fingerprint }}
+      {{ $stylesheet = $fingerprintedStyles }}
+      <link rel="stylesheet" href="{{ $stylesheet.RelPermalink }}" integrity="{{ $stylesheet.Data.Integrity }}">
+    {{ else }}
+      {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/products/single.html." }}
+    {{ end }}
   {{ else }}
     {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/products/single.html. Main stylesheet will be missing for product pages." }}
   {{ end }}


### PR DESCRIPTION
This commit further refines the SCSS processing in Hugo templates to prevent build errors and improve diagnostics related to the main stylesheet (`assets/scss/style.scss`).

1.  **`layouts/partials/head.html` Updated:**
    *   The SCSS processing logic now first uses `resources.Get` to fetch `assets/scss/style.scss`.
    *   It then explicitly checks if the resource was found AND if its `.Content` is not empty before attempting to process it with `resources.Sass` and `resources.Minify`.
    *   If the resource is not found or is empty, a `warnf` message is logged to the build output, and the stylesheet link is omitted.

2.  **`layouts/products/single.html` Updated:**
    *   Applied the same robust SCSS processing pattern. It also checks for the existence and non-empty content of `assets/scss/style.scss` before processing with `resources.Sass`, `resources.Minify`, and `resources.Fingerprint`.
    *   Appropriate `warnf` messages are logged if issues are encountered.

These changes ensure that the build does not fail due to an inability to process an SCSS file that is missing, empty, or otherwise problematic for `resources.Get`, and provides clearer warnings in the build logs for such scenarios.