### PR TITLE
diag: Temporarily simplify SCSS processing for diagnosis

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,8 +26,7 @@
   {{ if $originalResource }}
     {{ if ne $originalResource.Content "" }} {{/* Check if content is not empty */}}
       {{ $processedStyles := resources.Sass $originalResource $scssOptions }}
-      {{ $minifiedStyles := $processedStyles | resources.Minify }}
-      {{ $stylesheet = $minifiedStyles }}
+      {{ $stylesheet = $processedStyles }} {{/* Temporarily skip Minify */}}
       <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
     {{ else }}
       {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/partials/head.html." }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -62,10 +62,8 @@
   {{ if $originalResource }}
     {{ if ne $originalResource.Content "" }} {{/* Check if content is not empty */}}
       {{ $processedStyles := resources.Sass $originalResource $scssOptions }}
-      {{ $minifiedStyles := $processedStyles | resources.Minify }}
-      {{ $fingerprintedStyles := $minifiedStyles | resources.Fingerprint }}
-      {{ $stylesheet = $fingerprintedStyles }}
-      <link rel="stylesheet" href="{{ $stylesheet.RelPermalink }}" integrity="{{ $stylesheet.Data.Integrity }}">
+      {{ $stylesheet = $processedStyles }} {{/* Temporarily skip Minify and Fingerprint */}}
+      <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity=""> {{/* No integrity without fingerprint */}}
     {{ else }}
       {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/products/single.html." }}
     {{ end }}


### PR DESCRIPTION
This commit is for diagnostic purposes to help isolate a persistent Hugo build error: "can't evaluate field Sass in type interface {}".

The following changes have been made:

1.  **`layouts/partials/head.html` SCSS Processing Simplified:**
    *   The `resources.Minify` step has been temporarily removed from the SCSS processing pipeline. The stylesheet link will now use the direct output of `resources.Sass`.

2.  **`layouts/products/single.html` SCSS Processing Simplified:**
    *   The `resources.Minify` and `resources.Fingerprint` steps have been temporarily removed from the SCSS processing pipeline.
    *   The `integrity` attribute has been cleared from the stylesheet's `<link>` tag as it's no longer valid without fingerprinting. The stylesheet link will use the direct output of `resources.Sass`.

These changes will help determine if the build error is occurring within the `resources.Sass` call itself or in the subsequent minification/fingerprinting steps.