### PR TITLE
diag: Add detailed debugging for SCSS resource handling

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,16 +23,28 @@
 
   {{ $originalResource := resources.Get $scssFile }}
 
+  {{/* --- DEBUGGING BLOCK START --- */}}
+  {{ if $originalResource }}
+    {{ warnf "DEBUG head.html: Found $originalResource. Name: %s, Type: %T, MediaType: %s, Content Length: %d" $originalResource.Name (printf "%T" $originalResource) $originalResource.MediaType (len $originalResource.Content) }}
+    {{/* Let's try to see if .RelPermalink exists on $originalResource directly, indicating it's some kind of file */}}
+    {{ warnf "DEBUG head.html: $originalResource.Permalink: %s" $originalResource.Permalink }}
+    {{ warnf "DEBUG head.html: $originalResource.RelPermalink: %s" $originalResource.RelPermalink }}
+  {{ else }}
+    {{ warnf "DEBUG head.html: $originalResource for %s is NIL." $scssFile }}
+  {{ end }}
+  {{/* --- DEBUGGING BLOCK END --- */}}
+
+
   {{ if $originalResource }}
     {{ if ne $originalResource.Content "" }} {{/* Check if content is not empty */}}
       {{ $processedStyles := resources.Sass $originalResource $scssOptions }}
       {{ $stylesheet = $processedStyles }} {{/* Temporarily skip Minify */}}
       <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
     {{ else }}
-      {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/partials/head.html." }}
+      {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/partials/head.html. (Content check)" }}
     {{ end }}
   {{ else }}
-    {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/partials/head.html. Main stylesheet will be missing." }}
+    {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/partials/head.html. (Resource check)" }}
   {{ end }}
 
   {{ "<!--Favicon-->" | safeHTML }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -59,16 +59,27 @@
 
   {{ $originalResource := resources.Get $scssFile }}
 
+  {{/* --- DEBUGGING BLOCK START --- */}}
+  {{ if $originalResource }}
+    {{ warnf "DEBUG products/single.html: Found $originalResource. Name: %s, Type: %T, MediaType: %s, Content Length: %d" $originalResource.Name (printf "%T" $originalResource) $originalResource.MediaType (len $originalResource.Content) }}
+    {{ warnf "DEBUG products/single.html: $originalResource.Permalink: %s" $originalResource.Permalink }}
+    {{ warnf "DEBUG products/single.html: $originalResource.RelPermalink: %s" $originalResource.RelPermalink }}
+  {{ else }}
+    {{ warnf "DEBUG products/single.html: $originalResource for %s is NIL." $scssFile }}
+  {{ end }}
+  {{/* --- DEBUGGING BLOCK END --- */}}
+
+
   {{ if $originalResource }}
     {{ if ne $originalResource.Content "" }} {{/* Check if content is not empty */}}
       {{ $processedStyles := resources.Sass $originalResource $scssOptions }}
       {{ $stylesheet = $processedStyles }} {{/* Temporarily skip Minify and Fingerprint */}}
       <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity=""> {{/* No integrity without fingerprint */}}
     {{ else }}
-      {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/products/single.html." }}
+      {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/products/single.html. (Content check)" }}
     {{ end }}
   {{ else }}
-    {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/products/single.html. Main stylesheet will be missing for product pages." }}
+    {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/products/single.html. (Resource check)" }}
   {{ end }}
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"


### PR DESCRIPTION
This commit adds detailed `warnf` logging to the SCSS processing pipelines in `layouts/partials/head.html` and `layouts/products/single.html`.

The purpose of these logs is to capture information about the resource object returned by `resources.Get "scss/style.scss"` in different rendering contexts. For the identified resource, the logs will include:
- Name
- Go Type (`%T`)
- MediaType
- Content Length
- Permalink
- RelPermalink

This information is intended to help diagnose a persistent Hugo build error ("can't evaluate field Sass in type interface {}") by revealing exactly what kind of object `resources.Sass` is receiving.

The actual SCSS processing logic (temporarily simplified without minification or fingerprinting) remains in place after the debugging output.