### PR TITLE
I've made some changes to the code to help figure out a problem with …

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,34 +17,47 @@
   {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
-  {{ $scssFile := "scss/style.scss" }}
+  {{ $scssPathKey := "scss/style.scss" }}
   {{ $scssOptions := (dict "outputStyle" "compressed") }}
-  {{ $stylesheet := "" }} {{/* Initialize $stylesheet */}}
+  {{ $stylesheet := "" }} {{/* Initialize */}}
 
-  {{ $originalResource := resources.Get $scssFile }}
+  {{ $initialResourceAttempt := resources.Get $scssPathKey }}
+  {{ $actualResource := "" }} {{/* Initialize */}}
+  {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
 
-  {{/* --- DEBUGGING BLOCK START --- */}}
-  {{ if $originalResource }}
-    {{ warnf "DEBUG head.html: Found $originalResource. Name: %s, Type: %T, MediaType: %s, Content Length: %d" $originalResource.Name (printf "%T" $originalResource) $originalResource.MediaType (len $originalResource.Content) }}
-    {{/* Let's try to see if .RelPermalink exists on $originalResource directly, indicating it's some kind of file */}}
-    {{ warnf "DEBUG head.html: $originalResource.Permalink: %s" $originalResource.Permalink }}
-    {{ warnf "DEBUG head.html: $originalResource.RelPermalink: %s" $originalResource.RelPermalink }}
+  {{ if eq $debugInitialType "string" }}
+    {{ warnf "DEBUG head.html: Initial attempt for '%s' returned a STRING: '%s'. Attempting to re-get using this string as path." $scssPathKey $initialResourceAttempt }}
+    {{ $actualResource = resources.Get $initialResourceAttempt }}
   {{ else }}
-    {{ warnf "DEBUG head.html: $originalResource for %s is NIL." $scssFile }}
+    {{ $actualResource = $initialResourceAttempt }}
+  {{ end }}
+
+  {{/* --- DEBUGGING BLOCK for $actualResource --- */}}
+  {{ if $actualResource }}
+    {{ warnf "DEBUG head.html: $actualResource after re-get logic. Name: %s, Type: %T, MediaType: %s, Content Length: %d" $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
+    {{ warnf "DEBUG head.html: $actualResource.Permalink: %s" $actualResource.Permalink }}
+    {{ warnf "DEBUG head.html: $actualResource.RelPermalink: %s" $actualResource.RelPermalink }}
+  {{ else }}
+    {{ warnf "DEBUG head.html: $actualResource for '%s' is NIL (Initial type was: %s)." $scssPathKey $debugInitialType }}
   {{ end }}
   {{/* --- DEBUGGING BLOCK END --- */}}
 
 
-  {{ if $originalResource }}
-    {{ if ne $originalResource.Content "" }} {{/* Check if content is not empty */}}
-      {{ $processedStyles := resources.Sass $originalResource $scssOptions }}
-      {{ $stylesheet = $processedStyles }} {{/* Temporarily skip Minify */}}
-      <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
+  {{ if $actualResource }}
+    {{ if ne $actualResource.Content "" }}
+      {{/* Ensure $actualResource is truly a resource object that resources.Sass can handle */}}
+      {{ if not (eq (printf "%T" $actualResource) "string") }}
+        {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
+        {{ $stylesheet = $processedStyles }}
+        <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
+      {{ else }}
+        {{ warnf "ERROR head.html: $actualResource is STILL a string ('%s') after re-get logic. Cannot process with resources.Sass." $actualResource }}
+      {{ end }}
     {{ else }}
-      {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/partials/head.html. (Content check)" }}
+      {{ warnf "SCSS resource %s is empty. (Content check on $actualResource)" $scssPathKey }}
     {{ end }}
   {{ else }}
-    {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/partials/head.html. (Resource check)" }}
+    {{ warnf "SCSS resource %s not found. (Resource check on $actualResource)" $scssPathKey }}
   {{ end }}
 
   {{ "<!--Favicon-->" | safeHTML }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -53,33 +53,48 @@
   {{ template "_internal/google_analytics.html" . }}
 
   {{/* ─────── 3) Chargement des CSS : Vex, Bootstrap, puis ton CSS perso ─────── */}}
-  {{ $scssFile := "scss/style.scss" }}
+  {{ $scssPathKey := "scss/style.scss" }}
   {{ $scssOptions := (dict "outputStyle" "compressed") }}
-  {{ $stylesheet := "" }} {{/* Initialize $stylesheet */}}
+  {{ $stylesheet := "" }} {{/* Initialize */}}
 
-  {{ $originalResource := resources.Get $scssFile }}
+  {{ $initialResourceAttempt := resources.Get $scssPathKey }}
+  {{ $actualResource := "" }} {{/* Initialize */}}
+  {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
 
-  {{/* --- DEBUGGING BLOCK START --- */}}
-  {{ if $originalResource }}
-    {{ warnf "DEBUG products/single.html: Found $originalResource. Name: %s, Type: %T, MediaType: %s, Content Length: %d" $originalResource.Name (printf "%T" $originalResource) $originalResource.MediaType (len $originalResource.Content) }}
-    {{ warnf "DEBUG products/single.html: $originalResource.Permalink: %s" $originalResource.Permalink }}
-    {{ warnf "DEBUG products/single.html: $originalResource.RelPermalink: %s" $originalResource.RelPermalink }}
+  {{ if eq $debugInitialType "string" }}
+    {{ warnf "DEBUG products/single.html: Initial attempt for '%s' returned a STRING: '%s'. Attempting to re-get using this string as path." $scssPathKey $initialResourceAttempt }}
+    {{ $actualResource = resources.Get $initialResourceAttempt }}
   {{ else }}
-    {{ warnf "DEBUG products/single.html: $originalResource for %s is NIL." $scssFile }}
+    {{ $actualResource = $initialResourceAttempt }}
+  {{ end }}
+
+  {{/* --- DEBUGGING BLOCK for $actualResource --- */}}
+  {{ if $actualResource }}
+    {{ warnf "DEBUG products/single.html: $actualResource after re-get logic. Name: %s, Type: %T, MediaType: %s, Content Length: %d" $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
+    {{ warnf "DEBUG products/single.html: $actualResource.Permalink: %s" $actualResource.Permalink }}
+    {{ warnf "DEBUG products/single.html: $actualResource.RelPermalink: %s" $actualResource.RelPermalink }}
+  {{ else }}
+    {{ warnf "DEBUG products/single.html: $actualResource for '%s' is NIL (Initial type was: %s)." $scssPathKey $debugInitialType }}
   {{ end }}
   {{/* --- DEBUGGING BLOCK END --- */}}
 
 
-  {{ if $originalResource }}
-    {{ if ne $originalResource.Content "" }} {{/* Check if content is not empty */}}
-      {{ $processedStyles := resources.Sass $originalResource $scssOptions }}
-      {{ $stylesheet = $processedStyles }} {{/* Temporarily skip Minify and Fingerprint */}}
-      <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity=""> {{/* No integrity without fingerprint */}}
+  {{ if $actualResource }}
+    {{ if ne $actualResource.Content "" }}
+      {{/* Ensure $actualResource is truly a resource object that resources.Sass can handle */}}
+      {{ if not (eq (printf "%T" $actualResource) "string") }}
+        {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
+        {{ $stylesheet = $processedStyles }}
+        {{/* Link for products/single.html (was previously fingerprinted, but simplified for diagnosis) */}}
+        <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity="">
+      {{ else }}
+        {{ warnf "ERROR products/single.html: $actualResource is STILL a string ('%s') after re-get logic. Cannot process with resources.Sass." $actualResource }}
+      {{ end }}
     {{ else }}
-      {{ warnf "SCSS resource assets/scss/style.scss is empty when processed in layouts/products/single.html. (Content check)" }}
+      {{ warnf "SCSS resource %s is empty in products/single.html. (Content check on $actualResource)" $scssPathKey }}
     {{ end }}
   {{ else }}
-    {{ warnf "SCSS resource assets/scss/style.scss not found when processed in layouts/products/single.html. (Resource check)" }}
+    {{ warnf "SCSS resource %s not found in products/single.html. (Resource check on $actualResource)" $scssPathKey }}
   {{ end }}
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"


### PR DESCRIPTION
…how SCSS resources are handled.

Here's what I did:

1.  **Updated SCSS Processing in `layouts/partials/head.html` and `layouts/products/single.html`:**
    *   I first try to get the SCSS file using `resources.Get "scss/style.scss"`.
    *   Then, I check what kind of object is returned.
    *   If it looks like a file path instead of the actual resource, I log this and try to get the resource again using that path.
    *   I've added a lot of debugging messages to track information about the resource object at different steps.
    *   I've also put in a check to make sure the resource is not just a file path before trying to process it with `resources.Sass`.
    *   For now, I've kept the SCSS processing simple to make it easier to see what's happening.

The goal of these changes is to get a better understanding of how Hugo is finding and identifying the `assets/scss/style.scss` file in different parts of your website. This should help pinpoint why the `resources.Sass` step is causing an error.