### PR TITLE
Here's the updated plan:

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,21 +24,26 @@
   {{ $initialResourceAttempt := resources.Get $scssPathKey }}
   {{ $actualResource := "" }} {{/* Initialize */}}
   {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
+  {{ $debugSourceMethod := "initial resources.Get" }} {{/* For logging */}}
 
   {{ if eq $debugInitialType "string" }}
-    {{ warnf "DEBUG head.html: Initial attempt for '%s' returned a STRING: '%s'. Attempting to re-get using this string as path." $scssPathKey $initialResourceAttempt }}
-    {{ $actualResource = resources.Get $initialResourceAttempt }}
+    {{ warnf "DEBUG head.html: Initial resources.Get for '%s' returned a STRING: '%s'. Attempting resources.Match with this string." $scssPathKey $initialResourceAttempt }}
+    {{ $matchedResources := resources.Match $initialResourceAttempt }}
+    {{ if gt (len $matchedResources) 0 }}
+      {{ $actualResource = index $matchedResources 0 }}
+      {{ $debugSourceMethod = "resources.Match fallback" }}
+    {{ else }}
+      {{ warnf "DEBUG head.html: resources.Match for string '%s' found no resources." $initialResourceAttempt }}
+    {{ end }}
   {{ else }}
     {{ $actualResource = $initialResourceAttempt }}
   {{ end }}
 
   {{/* --- DEBUGGING BLOCK for $actualResource --- */}}
   {{ if $actualResource }}
-    {{ warnf "DEBUG head.html: $actualResource after re-get logic. Name: %s, Type: %T, MediaType: %s, Content Length: %d" $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
-    {{ warnf "DEBUG head.html: $actualResource.Permalink: %s" $actualResource.Permalink }}
-    {{ warnf "DEBUG head.html: $actualResource.RelPermalink: %s" $actualResource.RelPermalink }}
+    {{ warnf "DEBUG head.html: $actualResource (obtained via %s). Name: %s, Type: %T, MediaType: %s, Content Length: %d" $debugSourceMethod $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
   {{ else }}
-    {{ warnf "DEBUG head.html: $actualResource for '%s' is NIL (Initial type was: %s)." $scssPathKey $debugInitialType }}
+    {{ warnf "DEBUG head.html: $actualResource for '%s' is NIL (Initial type was: %s, Source method: %s)." $scssPathKey $debugInitialType $debugSourceMethod }}
   {{ end }}
   {{/* --- DEBUGGING BLOCK END --- */}}
 
@@ -51,13 +56,13 @@
         {{ $stylesheet = $processedStyles }}
         <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
       {{ else }}
-        {{ warnf "ERROR head.html: $actualResource is STILL a string ('%s') after re-get logic. Cannot process with resources.Sass." $actualResource }}
+        {{ warnf "ERROR head.html: $actualResource is STILL a string ('%s') even after fallback logic. Cannot process with resources.Sass. Source: %s" $actualResource $debugSourceMethod }}
       {{ end }}
     {{ else }}
-      {{ warnf "SCSS resource %s is empty. (Content check on $actualResource)" $scssPathKey }}
+      {{ warnf "SCSS resource %s (%s) is empty. (Content check on $actualResource)" $scssPathKey $debugSourceMethod }}
     {{ end }}
   {{ else }}
-    {{ warnf "SCSS resource %s not found. (Resource check on $actualResource)" $scssPathKey }}
+    {{ warnf "SCSS resource %s (%s) not found. (Resource check on $actualResource)" $scssPathKey $debugSourceMethod }}
   {{ end }}
 
   {{ "<!--Favicon-->" | safeHTML }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -60,21 +60,26 @@
   {{ $initialResourceAttempt := resources.Get $scssPathKey }}
   {{ $actualResource := "" }} {{/* Initialize */}}
   {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
+  {{ $debugSourceMethod := "initial resources.Get" }} {{/* For logging */}}
 
   {{ if eq $debugInitialType "string" }}
-    {{ warnf "DEBUG products/single.html: Initial attempt for '%s' returned a STRING: '%s'. Attempting to re-get using this string as path." $scssPathKey $initialResourceAttempt }}
-    {{ $actualResource = resources.Get $initialResourceAttempt }}
+    {{ warnf "DEBUG products/single.html: Initial resources.Get for '%s' returned a STRING: '%s'. Attempting resources.Match with this string." $scssPathKey $initialResourceAttempt }}
+    {{ $matchedResources := resources.Match $initialResourceAttempt }}
+    {{ if gt (len $matchedResources) 0 }}
+      {{ $actualResource = index $matchedResources 0 }}
+      {{ $debugSourceMethod = "resources.Match fallback" }}
+    {{ else }}
+      {{ warnf "DEBUG products/single.html: resources.Match for string '%s' found no resources." $initialResourceAttempt }}
+    {{ end }}
   {{ else }}
     {{ $actualResource = $initialResourceAttempt }}
   {{ end }}
 
   {{/* --- DEBUGGING BLOCK for $actualResource --- */}}
   {{ if $actualResource }}
-    {{ warnf "DEBUG products/single.html: $actualResource after re-get logic. Name: %s, Type: %T, MediaType: %s, Content Length: %d" $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
-    {{ warnf "DEBUG products/single.html: $actualResource.Permalink: %s" $actualResource.Permalink }}
-    {{ warnf "DEBUG products/single.html: $actualResource.RelPermalink: %s" $actualResource.RelPermalink }}
+    {{ warnf "DEBUG products/single.html: $actualResource (obtained via %s). Name: %s, Type: %T, MediaType: %s, Content Length: %d" $debugSourceMethod $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
   {{ else }}
-    {{ warnf "DEBUG products/single.html: $actualResource for '%s' is NIL (Initial type was: %s)." $scssPathKey $debugInitialType }}
+    {{ warnf "DEBUG products/single.html: $actualResource for '%s' is NIL (Initial type was: %s, Source method: %s)." $scssPathKey $debugInitialType $debugSourceMethod }}
   {{ end }}
   {{/* --- DEBUGGING BLOCK END --- */}}
 
@@ -85,16 +90,16 @@
       {{ if not (eq (printf "%T" $actualResource) "string") }}
         {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
         {{ $stylesheet = $processedStyles }}
-        {{/* Link for products/single.html (was previously fingerprinted, but simplified for diagnosis) */}}
+        {{/* Link for products/single.html (integrity attribute is empty as Minify/Fingerprint are still out for diagnosis) */}}
         <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity="">
       {{ else }}
-        {{ warnf "ERROR products/single.html: $actualResource is STILL a string ('%s') after re-get logic. Cannot process with resources.Sass." $actualResource }}
+        {{ warnf "ERROR products/single.html: $actualResource is STILL a string ('%s') even after fallback logic. Cannot process with resources.Sass. Source: %s" $actualResource $debugSourceMethod }}
       {{ end }}
     {{ else }}
-      {{ warnf "SCSS resource %s is empty in products/single.html. (Content check on $actualResource)" $scssPathKey }}
+      {{ warnf "SCSS resource %s (%s) is empty in products/single.html. (Content check on $actualResource)" $scssPathKey $debugSourceMethod }}
     {{ end }}
   {{ else }}
-    {{ warnf "SCSS resource %s not found in products/single.html. (Resource check on $actualResource)" $scssPathKey }}
+    {{ warnf "SCSS resource %s (%s) not found in products/single.html. (Resource check on $actualResource)" $scssPathKey $debugSourceMethod }}
   {{ end }}
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"


### PR DESCRIPTION
diag: Use resources.Match as fallback for SCSS processing

This commit introduces a fallback mechanism using `resources.Match` in the SCSS processing pipeline. I'm doing this in an attempt to further diagnose and potentially resolve a persistent Hugo build error ("can't evaluate field Sass in type interface {}") where `resources.Get` might be returning a string path instead of a Resource object.

1.  **SCSS Processing Updated in `layouts/partials/head.html` and `layouts/products/single.html`:**
    *   The logic will now first attempt `resources.Get "scss/style.scss"`.
    *   If the result of `resources.Get` is a string (unexpected behavior), it will log this and then use that string path with `resources.Match` to attempt to find the resource.
    *   If `resources.Match` returns one or more resources, the first one will be used.
    *   Extensive `warnf` debugging statements will remain in place to log the type, name, and other properties of the resource object at each stage (initial attempt, after `resources.Match` fallback) and to indicate which method was used to obtain the final resource.
    *   The code will still check if the final resource object is valid and non-empty before attempting `resources.Sass`.
    *   An explicit check will also be added to ensure the object passed to `resources.Sass` is not a string, with an error log if it still is.
    *   The SCSS processing pipeline will remain simplified (no Minify/Fingerprint) for diagnostic clarity.

This change aims to robustly obtain a valid Resource object for `assets/scss/style.scss` even if `resources.Get` behaves unexpectedly, and to provide detailed logs for analysis.