### PR TITLE
diag: Trim leading slash and use Match for SCSS resources

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,15 +25,27 @@
   {{ $actualResource := "" }} {{/* Initialize */}}
   {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
   {{ $debugSourceMethod := "initial resources.Get" }} {{/* For logging */}}
+  {{ $correctedPathForNextAttempt := $scssPathKey }} {{/* Default path for any re-attempts */}}
+
 
   {{ if eq $debugInitialType "string" }}
-    {{ warnf "DEBUG head.html: Initial resources.Get for '%s' returned a STRING: '%s'. Attempting resources.Match with this string." $scssPathKey $initialResourceAttempt }}
-    {{ $matchedResources := resources.Match $initialResourceAttempt }}
+    {{ $pathStringFromGet := $initialResourceAttempt }}
+    {{ if strings.HasPrefix $pathStringFromGet "/" }}
+      {{ $correctedPathForNextAttempt = strings.TrimPrefix "/" $pathStringFromGet }}
+      {{ warnf "DEBUG head.html: Initial resources.Get for '%s' returned STRING '%s'. Trimmed leading '/' to '%s' for next Match attempt." $scssPathKey $pathStringFromGet $correctedPathForNextAttempt }}
+    {{ else }}
+      {{ $correctedPathForNextAttempt = $pathStringFromGet }}
+      {{ warnf "DEBUG head.html: Initial resources.Get for '%s' returned STRING '%s'. No leading '/' to trim. Using as is for next Match attempt." $scssPathKey $pathStringFromGet }}
+    {{ end }}
+
+    {{ $matchedResources := resources.Match $correctedPathForNextAttempt }}
     {{ if gt (len $matchedResources) 0 }}
       {{ $actualResource = index $matchedResources 0 }}
-      {{ $debugSourceMethod = "resources.Match fallback" }}
+      {{ $debugSourceMethod = (printf "resources.Match fallback on '%s'" $correctedPathForNextAttempt) }}
     {{ else }}
-      {{ warnf "DEBUG head.html: resources.Match for string '%s' found no resources." $initialResourceAttempt }}
+      {{ warnf "DEBUG head.html: resources.Match for path '%s' found NO resources. $initialResourceAttempt (type: %s) will be used directly." $correctedPathForNextAttempt $debugInitialType }}
+      {{ $actualResource = $initialResourceAttempt }} {{/* If match fails, pass on the original string to see its type logged by next debug block */}}
+       {{ $debugSourceMethod = (printf "original string from resources.Get ('%s') after Match failed on '%s'" $initialResourceAttempt $correctedPathForNextAttempt) }}
     {{ end }}
   {{ else }}
     {{ $actualResource = $initialResourceAttempt }}
@@ -50,7 +62,6 @@
 
   {{ if $actualResource }}
     {{ if ne $actualResource.Content "" }}
-      {{/* Ensure $actualResource is truly a resource object that resources.Sass can handle */}}
       {{ if not (eq (printf "%T" $actualResource) "string") }}
         {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
         {{ $stylesheet = $processedStyles }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -61,15 +61,27 @@
   {{ $actualResource := "" }} {{/* Initialize */}}
   {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
   {{ $debugSourceMethod := "initial resources.Get" }} {{/* For logging */}}
+  {{ $correctedPathForNextAttempt := $scssPathKey }} {{/* Default path for any re-attempts */}}
+
 
   {{ if eq $debugInitialType "string" }}
-    {{ warnf "DEBUG products/single.html: Initial resources.Get for '%s' returned a STRING: '%s'. Attempting resources.Match with this string." $scssPathKey $initialResourceAttempt }}
-    {{ $matchedResources := resources.Match $initialResourceAttempt }}
+    {{ $pathStringFromGet := $initialResourceAttempt }}
+    {{ if strings.HasPrefix $pathStringFromGet "/" }}
+      {{ $correctedPathForNextAttempt = strings.TrimPrefix "/" $pathStringFromGet }}
+      {{ warnf "DEBUG products/single.html: Initial resources.Get for '%s' returned STRING '%s'. Trimmed leading '/' to '%s' for next Match attempt." $scssPathKey $pathStringFromGet $correctedPathForNextAttempt }}
+    {{ else }}
+      {{ $correctedPathForNextAttempt = $pathStringFromGet }}
+      {{ warnf "DEBUG products/single.html: Initial resources.Get for '%s' returned STRING '%s'. No leading '/' to trim. Using as is for next Match attempt." $scssPathKey $pathStringFromGet }}
+    {{ end }}
+
+    {{ $matchedResources := resources.Match $correctedPathForNextAttempt }}
     {{ if gt (len $matchedResources) 0 }}
       {{ $actualResource = index $matchedResources 0 }}
-      {{ $debugSourceMethod = "resources.Match fallback" }}
+      {{ $debugSourceMethod = (printf "resources.Match fallback on '%s'" $correctedPathForNextAttempt) }}
     {{ else }}
-      {{ warnf "DEBUG products/single.html: resources.Match for string '%s' found no resources." $initialResourceAttempt }}
+      {{ warnf "DEBUG products/single.html: resources.Match for path '%s' found NO resources. $initialResourceAttempt (type: %s) will be used directly." $correctedPathForNextAttempt $debugInitialType }}
+      {{ $actualResource = $initialResourceAttempt }} {{/* If match fails, pass on the original string to see its type logged by next debug block */}}
+       {{ $debugSourceMethod = (printf "original string from resources.Get ('%s') after Match failed on '%s'" $initialResourceAttempt $correctedPathForNextAttempt) }}
     {{ end }}
   {{ else }}
     {{ $actualResource = $initialResourceAttempt }}
@@ -86,12 +98,10 @@
 
   {{ if $actualResource }}
     {{ if ne $actualResource.Content "" }}
-      {{/* Ensure $actualResource is truly a resource object that resources.Sass can handle */}}
       {{ if not (eq (printf "%T" $actualResource) "string") }}
         {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
         {{ $stylesheet = $processedStyles }}
-        {{/* Link for products/single.html (integrity attribute is empty as Minify/Fingerprint are still out for diagnosis) */}}
-        <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity="">
+        <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity=""> {{/* Still no integrity for diagnosis */}}
       {{ else }}
         {{ warnf "ERROR products/single.html: $actualResource is STILL a string ('%s') even after fallback logic. Cannot process with resources.Sass. Source: %s" $actualResource $debugSourceMethod }}
       {{ end }}


### PR DESCRIPTION
This commit introduces a further refinement to the SCSS resource handling in an attempt to resolve the persistent "can't evaluate field Sass in type interface {}" error.

The previous diagnostic logs indicated that `resources.Get "scss/style.scss"` was returning a string path (e.g., "/scss/style.scss") instead of a Resource object in certain contexts. This commit attempts to handle this:

1.  **SCSS Processing Updated in `layouts/partials/head.html` and `layouts/products/single.html`:**
    *   The logic still first attempts `resources.Get "scss/style.scss"`.
    *   If the result is a string:
        *   It now checks if this string path has a leading slash (`/`).
        *   If a leading slash is present, it is trimmed off (e.g., "/scss/style.scss" becomes "scss/style.scss").
        *   This corrected path is then used with `resources.Match` to attempt to find the resource.
        *   If `resources.Match` finds one or more resources, the first one is used.
    *   If the initial `resources.Get` does not return a string, that result is used directly.
    *   Extensive `warnf` debugging logs remain to trace this process, including the corrected path used and the source method of the final resource object.
    *   The code still checks if the final resource object is valid and non-empty before attempting `resources.Sass`.
    *   SCSS processing remains simplified (no Minify/Fingerprint) for diagnostic clarity.

This change is specifically targeted at the observation that `resources.Get` was returning a path string and that this path string had a leading slash, which might affect how `resources.Match` or a subsequent `resources.Get` (if it were used) would interpret the path relative to the `assets` directory.