### PR TITLE
fix: Use readFile and resources.FromString for SCSS processing

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,63 +17,42 @@
   {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
-  {{ $scssPathKey := "scss/style.scss" }}
+  {{ $scssFilePath := "assets/scss/style.scss" }} {{/* Path relative to project root for readFile */}}
+  {{ $targetResourceName := "scss/style.scss" }} {{/* Target name/path for the resource created by FromString */}}
   {{ $scssOptions := (dict "outputStyle" "compressed") }}
   {{ $stylesheet := "" }} {{/* Initialize */}}
 
-  {{ $initialResourceAttempt := resources.Get $scssPathKey }}
-  {{ $actualResource := "" }} {{/* Initialize */}}
-  {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
-  {{ $debugSourceMethod := "initial resources.Get" }} {{/* For logging */}}
-  {{ $correctedPathForNextAttempt := $scssPathKey }} {{/* Default path for any re-attempts */}}
+  {{ $fileContent := "" }}
+  {{ $fileExists := fileExists $scssFilePath }}
 
-
-  {{ if eq $debugInitialType "string" }}
-    {{ $pathStringFromGet := $initialResourceAttempt }}
-    {{ if strings.HasPrefix $pathStringFromGet "/" }}
-      {{ $correctedPathForNextAttempt = strings.TrimPrefix "/" $pathStringFromGet }}
-      {{ warnf "DEBUG head.html: Initial resources.Get for '%s' returned STRING '%s'. Trimmed leading '/' to '%s' for next Match attempt." $scssPathKey $pathStringFromGet $correctedPathForNextAttempt }}
-    {{ else }}
-      {{ $correctedPathForNextAttempt = $pathStringFromGet }}
-      {{ warnf "DEBUG head.html: Initial resources.Get for '%s' returned STRING '%s'. No leading '/' to trim. Using as is for next Match attempt." $scssPathKey $pathStringFromGet }}
-    {{ end }}
-
-    {{ $matchedResources := resources.Match $correctedPathForNextAttempt }}
-    {{ if gt (len $matchedResources) 0 }}
-      {{ $actualResource = index $matchedResources 0 }}
-      {{ $debugSourceMethod = (printf "resources.Match fallback on '%s'" $correctedPathForNextAttempt) }}
-    {{ else }}
-      {{ warnf "DEBUG head.html: resources.Match for path '%s' found NO resources. $initialResourceAttempt (type: %s) will be used directly." $correctedPathForNextAttempt $debugInitialType }}
-      {{ $actualResource = $initialResourceAttempt }} {{/* If match fails, pass on the original string to see its type logged by next debug block */}}
-       {{ $debugSourceMethod = (printf "original string from resources.Get ('%s') after Match failed on '%s'" $initialResourceAttempt $correctedPathForNextAttempt) }}
-    {{ end }}
+  {{ if $fileExists }}
+    {{ $fileContent = readFile $scssFilePath }}
+    {{ warnf "DEBUG head.html: readFile '%s' - File exists. Content Length: %d" $scssFilePath (len $fileContent) }}
   {{ else }}
-    {{ $actualResource = $initialResourceAttempt }}
+    {{ warnf "DEBUG head.html: readFile '%s' - File does NOT exist." $scssFilePath }}
   {{ end }}
 
-  {{/* --- DEBUGGING BLOCK for $actualResource --- */}}
-  {{ if $actualResource }}
-    {{ warnf "DEBUG head.html: $actualResource (obtained via %s). Name: %s, Type: %T, MediaType: %s, Content Length: %d" $debugSourceMethod $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
-  {{ else }}
-    {{ warnf "DEBUG head.html: $actualResource for '%s' is NIL (Initial type was: %s, Source method: %s)." $scssPathKey $debugInitialType $debugSourceMethod }}
-  {{ end }}
-  {{/* --- DEBUGGING BLOCK END --- */}}
+  {{ if and $fileExists (ne $fileContent "") }}
+    {{/* Create a resource from the string content.
+         The second argument to resources.FromString is the target path/name for this resource.
+         It helps Hugo understand what kind of resource it is (e.g., by its .scss extension)
+         and is used in internal caching. */}}
+    {{ $scssResource := resources.FromString $targetResourceName $fileContent }}
 
-
-  {{ if $actualResource }}
-    {{ if ne $actualResource.Content "" }}
-      {{ if not (eq (printf "%T" $actualResource) "string") }}
-        {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
-        {{ $stylesheet = $processedStyles }}
-        <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
-      {{ else }}
-        {{ warnf "ERROR head.html: $actualResource is STILL a string ('%s') even after fallback logic. Cannot process with resources.Sass. Source: %s" $actualResource $debugSourceMethod }}
-      {{ end }}
+    {{ if $scssResource }}
+      {{ warnf "DEBUG head.html: Successfully created resource from string. Name: %s, Type: %T, MediaType: %s" $scssResource.Name (printf "%T" $scssResource) $scssResource.MediaType }}
+      {{ $processedStyles := resources.Sass $scssResource $scssOptions }}
+      {{ $stylesheet = $processedStyles }}
+      <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
     {{ else }}
-      {{ warnf "SCSS resource %s (%s) is empty. (Content check on $actualResource)" $scssPathKey $debugSourceMethod }}
+      {{ warnf "ERROR head.html: resources.FromString for target '%s' returned NIL." $targetResourceName }}
     {{ end }}
   {{ else }}
-    {{ warnf "SCSS resource %s (%s) not found. (Resource check on $actualResource)" $scssPathKey $debugSourceMethod }}
+    {{ if not $fileExists }}
+      {{ warnf "SCSS file '%s' not found by readFile. Main stylesheet will be missing." $scssFilePath }}
+    {{ else }}
+      {{ warnf "SCSS file '%s' is empty. Main stylesheet will be missing." $scssFilePath }}
+    {{ end }}
   {{ end }}
 
   {{ "<!--Favicon-->" | safeHTML }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -53,63 +53,38 @@
   {{ template "_internal/google_analytics.html" . }}
 
   {{/* ─────── 3) Chargement des CSS : Vex, Bootstrap, puis ton CSS perso ─────── */}}
-  {{ $scssPathKey := "scss/style.scss" }}
+  {{ $scssFilePath := "assets/scss/style.scss" }} {{/* Path relative to project root for readFile */}}
+  {{ $targetResourceName := "scss/style.scss" }} {{/* Target name/path for the resource created by FromString */}}
   {{ $scssOptions := (dict "outputStyle" "compressed") }}
   {{ $stylesheet := "" }} {{/* Initialize */}}
 
-  {{ $initialResourceAttempt := resources.Get $scssPathKey }}
-  {{ $actualResource := "" }} {{/* Initialize */}}
-  {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
-  {{ $debugSourceMethod := "initial resources.Get" }} {{/* For logging */}}
-  {{ $correctedPathForNextAttempt := $scssPathKey }} {{/* Default path for any re-attempts */}}
+  {{ $fileContent := "" }}
+  {{ $fileExists := fileExists $scssFilePath }}
 
-
-  {{ if eq $debugInitialType "string" }}
-    {{ $pathStringFromGet := $initialResourceAttempt }}
-    {{ if strings.HasPrefix $pathStringFromGet "/" }}
-      {{ $correctedPathForNextAttempt = strings.TrimPrefix "/" $pathStringFromGet }}
-      {{ warnf "DEBUG products/single.html: Initial resources.Get for '%s' returned STRING '%s'. Trimmed leading '/' to '%s' for next Match attempt." $scssPathKey $pathStringFromGet $correctedPathForNextAttempt }}
-    {{ else }}
-      {{ $correctedPathForNextAttempt = $pathStringFromGet }}
-      {{ warnf "DEBUG products/single.html: Initial resources.Get for '%s' returned STRING '%s'. No leading '/' to trim. Using as is for next Match attempt." $scssPathKey $pathStringFromGet }}
-    {{ end }}
-
-    {{ $matchedResources := resources.Match $correctedPathForNextAttempt }}
-    {{ if gt (len $matchedResources) 0 }}
-      {{ $actualResource = index $matchedResources 0 }}
-      {{ $debugSourceMethod = (printf "resources.Match fallback on '%s'" $correctedPathForNextAttempt) }}
-    {{ else }}
-      {{ warnf "DEBUG products/single.html: resources.Match for path '%s' found NO resources. $initialResourceAttempt (type: %s) will be used directly." $correctedPathForNextAttempt $debugInitialType }}
-      {{ $actualResource = $initialResourceAttempt }} {{/* If match fails, pass on the original string to see its type logged by next debug block */}}
-       {{ $debugSourceMethod = (printf "original string from resources.Get ('%s') after Match failed on '%s'" $initialResourceAttempt $correctedPathForNextAttempt) }}
-    {{ end }}
+  {{ if $fileExists }}
+    {{ $fileContent = readFile $scssFilePath }}
+    {{ warnf "DEBUG products/single.html: readFile '%s' - File exists. Content Length: %d" $scssFilePath (len $fileContent) }}
   {{ else }}
-    {{ $actualResource = $initialResourceAttempt }}
+    {{ warnf "DEBUG products/single.html: readFile '%s' - File does NOT exist." $scssFilePath }}
   {{ end }}
 
-  {{/* --- DEBUGGING BLOCK for $actualResource --- */}}
-  {{ if $actualResource }}
-    {{ warnf "DEBUG products/single.html: $actualResource (obtained via %s). Name: %s, Type: %T, MediaType: %s, Content Length: %d" $debugSourceMethod $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
-  {{ else }}
-    {{ warnf "DEBUG products/single.html: $actualResource for '%s' is NIL (Initial type was: %s, Source method: %s)." $scssPathKey $debugInitialType $debugSourceMethod }}
-  {{ end }}
-  {{/* --- DEBUGGING BLOCK END --- */}}
+  {{ if and $fileExists (ne $fileContent "") }}
+    {{ $scssResource := resources.FromString $targetResourceName $fileContent }}
 
-
-  {{ if $actualResource }}
-    {{ if ne $actualResource.Content "" }}
-      {{ if not (eq (printf "%T" $actualResource) "string") }}
-        {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
-        {{ $stylesheet = $processedStyles }}
-        <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity=""> {{/* Still no integrity for diagnosis */}}
-      {{ else }}
-        {{ warnf "ERROR products/single.html: $actualResource is STILL a string ('%s') even after fallback logic. Cannot process with resources.Sass. Source: %s" $actualResource $debugSourceMethod }}
-      {{ end }}
+    {{ if $scssResource }}
+      {{ warnf "DEBUG products/single.html: Successfully created resource from string. Name: %s, Type: %T, MediaType: %s" $scssResource.Name (printf "%T" $scssResource) $scssResource.MediaType }}
+      {{ $processedStyles := resources.Sass $scssResource $scssOptions }}
+      {{ $stylesheet = $processedStyles }}
+      <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity=""> {{/* No integrity as Fingerprint is out */}}
     {{ else }}
-      {{ warnf "SCSS resource %s (%s) is empty in products/single.html. (Content check on $actualResource)" $scssPathKey $debugSourceMethod }}
+      {{ warnf "ERROR products/single.html: resources.FromString for target '%s' returned NIL." $targetResourceName }}
     {{ end }}
   {{ else }}
-    {{ warnf "SCSS resource %s (%s) not found in products/single.html. (Resource check on $actualResource)" $scssPathKey $debugSourceMethod }}
+    {{ if not $fileExists }}
+      {{ warnf "SCSS file '%s' not found by readFile in products/single.html. Main stylesheet will be missing." $scssFilePath }}
+    {{ else }}
+      {{ warnf "SCSS file '%s' is empty in products/single.html. Main stylesheet will be missing." $scssFilePath }}
+    {{ end }}
   {{ end }}
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"


### PR DESCRIPTION
This commit implements a new strategy for SCSS processing in an attempt to resolve a persistent Hugo build error ("can't evaluate field Sass in type interface {}"). This error appeared to be caused by `resources.Get` unexpectedly returning a string path instead of a Resource object.

The new approach bypasses `resources.Get` for the initial file loading:

1.  **SCSS Processing Updated in `layouts/partials/head.html` and `layouts/products/single.html`:**
    *   The logic now uses `fileExists` to check for `assets/scss/style.scss`.
    *   If the file exists and is not empty, its raw string content is obtained.
    *   `resources.FromString` is then used to convert this string content into a Hugo Resource object, with a target name of "scss/style.scss" to help Hugo identify its type.
    *   This newly created Resource object is then passed to `resources.Sass` for compilation.
    *   Extensive `warnf` debugging logs remain in place to trace this new process, including the success/failure of obtaining the file content and `resources.FromString`, and details of the created resource.
    *   SCSS processing remains simplified (no Minify/Fingerprint) for diagnostic clarity.

This change aims to ensure that `resources.Sass` receives a validly constructed Resource object, even if `resources.Get` was failing to provide one.