### PR TITLE
Input:

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,42 +17,63 @@
   {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
-  {{ $scssFilePath := "assets/scss/style.scss" }} {{/* Path relative to project root for readFile */}}
-  {{ $targetResourceName := "scss/style.scss" }} {{/* Target name/path for the resource created by FromString */}}
+  {{ $scssPathKey := "assets/scss/style.scss" }} {{/* CHANGED THIS LINE */}}
   {{ $scssOptions := (dict "outputStyle" "compressed") }}
   {{ $stylesheet := "" }} {{/* Initialize */}}
 
-  {{ $fileContent := "" }}
-  {{ $fileExists := fileExists $scssFilePath }}
+  {{ $initialResourceAttempt := resources.Get $scssPathKey }}
+  {{ $actualResource := "" }} {{/* Initialize */}}
+  {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
+  {{ $debugSourceMethod := "initial resources.Get" }} {{/* For logging */}}
+  {{ $correctedPathForNextAttempt := $scssPathKey }} {{/* Default path for any re-attempts */}}
 
-  {{ if $fileExists }}
-    {{ $fileContent = readFile $scssFilePath }}
-    {{ warnf "DEBUG head.html: readFile '%s' - File exists. Content Length: %d" $scssFilePath (len $fileContent) }}
+
+  {{ if eq $debugInitialType "string" }}
+    {{ $pathStringFromGet := $initialResourceAttempt }}
+    {{ if strings.HasPrefix $pathStringFromGet "/" }}
+      {{ $correctedPathForNextAttempt = strings.TrimPrefix "/" $pathStringFromGet }}
+      {{ warnf "DEBUG head.html: Initial resources.Get for '%s' returned STRING '%s'. Trimmed leading '/' to '%s' for next Match attempt." $scssPathKey $pathStringFromGet $correctedPathForNextAttempt }}
+    {{ else }}
+      {{ $correctedPathForNextAttempt = $pathStringFromGet }}
+      {{ warnf "DEBUG head.html: Initial resources.Get for '%s' returned STRING '%s'. No leading '/' to trim. Using as is for next Match attempt." $scssPathKey $pathStringFromGet }}
+    {{ end }}
+
+    {{ $matchedResources := resources.Match $correctedPathForNextAttempt }}
+    {{ if gt (len $matchedResources) 0 }}
+      {{ $actualResource = index $matchedResources 0 }}
+      {{ $debugSourceMethod = (printf "resources.Match fallback on '%s'" $correctedPathForNextAttempt) }}
+    {{ else }}
+      {{ warnf "DEBUG head.html: resources.Match for path '%s' found NO resources. $initialResourceAttempt (type: %s) will be used directly." $correctedPathForNextAttempt $debugInitialType }}
+      {{ $actualResource = $initialResourceAttempt }} {{/* If match fails, pass on the original string to see its type logged by next debug block */}}
+       {{ $debugSourceMethod = (printf "original string from resources.Get ('%s') after Match failed on '%s'" $initialResourceAttempt $correctedPathForNextAttempt) }}
+    {{ end }}
   {{ else }}
-    {{ warnf "DEBUG head.html: readFile '%s' - File does NOT exist." $scssFilePath }}
+    {{ $actualResource = $initialResourceAttempt }}
   {{ end }}
 
-  {{ if and $fileExists (ne $fileContent "") }}
-    {{/* Create a resource from the string content.
-         The second argument to resources.FromString is the target path/name for this resource.
-         It helps Hugo understand what kind of resource it is (e.g., by its .scss extension)
-         and is used in internal caching. */}}
-    {{ $scssResource := resources.FromString $targetResourceName $fileContent }}
+  {{/* --- DEBUGGING BLOCK for $actualResource --- */}}
+  {{ if $actualResource }}
+    {{ warnf "DEBUG head.html: $actualResource (obtained via %s). Name: %s, Type: %T, MediaType: %s, Content Length: %d" $debugSourceMethod $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
+  {{ else }}
+    {{ warnf "DEBUG head.html: $actualResource for '%s' is NIL (Initial type was: %s, Source method: %s)." $scssPathKey $debugInitialType $debugSourceMethod }}
+  {{ end }}
+  {{/* --- DEBUGGING BLOCK END --- */}}
 
-    {{ if $scssResource }}
-      {{ warnf "DEBUG head.html: Successfully created resource from string. Name: %s, Type: %T, MediaType: %s" $scssResource.Name (printf "%T" $scssResource) $scssResource.MediaType }}
-      {{ $processedStyles := resources.Sass $scssResource $scssOptions }}
-      {{ $stylesheet = $processedStyles }}
-      <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
+
+  {{ if $actualResource }}
+    {{ if ne $actualResource.Content "" }}
+      {{ if not (eq (printf "%T" $actualResource) "string") }}
+        {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
+        {{ $stylesheet = $processedStyles }}
+        <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" media="screen">
+      {{ else }}
+        {{ warnf "ERROR head.html: $actualResource is STILL a string ('%s') even after fallback logic. Cannot process with resources.Sass. Source: %s" $actualResource $debugSourceMethod }}
+      {{ end }}
     {{ else }}
-      {{ warnf "ERROR head.html: resources.FromString for target '%s' returned NIL." $targetResourceName }}
+      {{ warnf "SCSS resource %s (%s) is empty. (Content check on $actualResource)" $scssPathKey $debugSourceMethod }}
     {{ end }}
   {{ else }}
-    {{ if not $fileExists }}
-      {{ warnf "SCSS file '%s' not found by readFile. Main stylesheet will be missing." $scssFilePath }}
-    {{ else }}
-      {{ warnf "SCSS file '%s' is empty. Main stylesheet will be missing." $scssFilePath }}
-    {{ end }}
+    {{ warnf "SCSS resource %s (%s) not found. (Resource check on $actualResource)" $scssPathKey $debugSourceMethod }}
   {{ end }}
 
   {{ "<!--Favicon-->" | safeHTML }}

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -53,38 +53,63 @@
   {{ template "_internal/google_analytics.html" . }}
 
   {{/* ─────── 3) Chargement des CSS : Vex, Bootstrap, puis ton CSS perso ─────── */}}
-  {{ $scssFilePath := "assets/scss/style.scss" }} {{/* Path relative to project root for readFile */}}
-  {{ $targetResourceName := "scss/style.scss" }} {{/* Target name/path for the resource created by FromString */}}
+  {{ $scssPathKey := "assets/scss/style.scss" }} {{/* CHANGED THIS LINE */}}
   {{ $scssOptions := (dict "outputStyle" "compressed") }}
   {{ $stylesheet := "" }} {{/* Initialize */}}
 
-  {{ $fileContent := "" }}
-  {{ $fileExists := fileExists $scssFilePath }}
+  {{ $initialResourceAttempt := resources.Get $scssPathKey }}
+  {{ $actualResource := "" }} {{/* Initialize */}}
+  {{ $debugInitialType := printf "%T" $initialResourceAttempt }}
+  {{ $debugSourceMethod := "initial resources.Get" }} {{/* For logging */}}
+  {{ $correctedPathForNextAttempt := $scssPathKey }} {{/* Default path for any re-attempts */}}
 
-  {{ if $fileExists }}
-    {{ $fileContent = readFile $scssFilePath }}
-    {{ warnf "DEBUG products/single.html: readFile '%s' - File exists. Content Length: %d" $scssFilePath (len $fileContent) }}
+
+  {{ if eq $debugInitialType "string" }}
+    {{ $pathStringFromGet := $initialResourceAttempt }}
+    {{ if strings.HasPrefix $pathStringFromGet "/" }}
+      {{ $correctedPathForNextAttempt = strings.TrimPrefix "/" $pathStringFromGet }}
+      {{ warnf "DEBUG products/single.html: Initial resources.Get for '%s' returned STRING '%s'. Trimmed leading '/' to '%s' for next Match attempt." $scssPathKey $pathStringFromGet $correctedPathForNextAttempt }}
+    {{ else }}
+      {{ $correctedPathForNextAttempt = $pathStringFromGet }}
+      {{ warnf "DEBUG products/single.html: Initial resources.Get for '%s' returned STRING '%s'. No leading '/' to trim. Using as is for next Match attempt." $scssPathKey $pathStringFromGet }}
+    {{ end }}
+
+    {{ $matchedResources := resources.Match $correctedPathForNextAttempt }}
+    {{ if gt (len $matchedResources) 0 }}
+      {{ $actualResource = index $matchedResources 0 }}
+      {{ $debugSourceMethod = (printf "resources.Match fallback on '%s'" $correctedPathForNextAttempt) }}
+    {{ else }}
+      {{ warnf "DEBUG products/single.html: resources.Match for path '%s' found NO resources. $initialResourceAttempt (type: %s) will be used directly." $correctedPathForNextAttempt $debugInitialType }}
+      {{ $actualResource = $initialResourceAttempt }} {{/* If match fails, pass on the original string to see its type logged by next debug block */}}
+       {{ $debugSourceMethod = (printf "original string from resources.Get ('%s') after Match failed on '%s'" $initialResourceAttempt $correctedPathForNextAttempt) }}
+    {{ end }}
   {{ else }}
-    {{ warnf "DEBUG products/single.html: readFile '%s' - File does NOT exist." $scssFilePath }}
+    {{ $actualResource = $initialResourceAttempt }}
   {{ end }}
 
-  {{ if and $fileExists (ne $fileContent "") }}
-    {{ $scssResource := resources.FromString $targetResourceName $fileContent }}
+  {{/* --- DEBUGGING BLOCK for $actualResource --- */}}
+  {{ if $actualResource }}
+    {{ warnf "DEBUG products/single.html: $actualResource (obtained via %s). Name: %s, Type: %T, MediaType: %s, Content Length: %d" $debugSourceMethod $actualResource.Name (printf "%T" $actualResource) $actualResource.MediaType (len $actualResource.Content) }}
+  {{ else }}
+    {{ warnf "DEBUG products/single.html: $actualResource for '%s' is NIL (Initial type was: %s, Source method: %s)." $scssPathKey $debugInitialType $debugSourceMethod }}
+  {{ end }}
+  {{/* --- DEBUGGING BLOCK END --- */}}
 
-    {{ if $scssResource }}
-      {{ warnf "DEBUG products/single.html: Successfully created resource from string. Name: %s, Type: %T, MediaType: %s" $scssResource.Name (printf "%T" $scssResource) $scssResource.MediaType }}
-      {{ $processedStyles := resources.Sass $scssResource $scssOptions }}
-      {{ $stylesheet = $processedStyles }}
-      <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity=""> {{/* No integrity as Fingerprint is out */}}
+
+  {{ if $actualResource }}
+    {{ if ne $actualResource.Content "" }}
+      {{ if not (eq (printf "%T" $actualResource) "string") }}
+        {{ $processedStyles := resources.Sass $actualResource $scssOptions }}
+        {{ $stylesheet = $processedStyles }}
+        <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" integrity=""> {{/* Still no integrity for diagnosis */}}
+      {{ else }}
+        {{ warnf "ERROR products/single.html: $actualResource is STILL a string ('%s') even after fallback logic. Cannot process with resources.Sass. Source: %s" $actualResource $debugSourceMethod }}
+      {{ end }}
     {{ else }}
-      {{ warnf "ERROR products/single.html: resources.FromString for target '%s' returned NIL." $targetResourceName }}
+      {{ warnf "SCSS resource %s (%s) is empty in products/single.html. (Content check on $actualResource)" $scssPathKey $debugSourceMethod }}
     {{ end }}
   {{ else }}
-    {{ if not $fileExists }}
-      {{ warnf "SCSS file '%s' not found by readFile in products/single.html. Main stylesheet will be missing." $scssFilePath }}
-    {{ else }}
-      {{ warnf "SCSS file '%s' is empty in products/single.html. Main stylesheet will be missing." $scssFilePath }}
-    {{ end }}
+    {{ warnf "SCSS resource %s (%s) not found in products/single.html. (Resource check on $actualResource)" $scssPathKey $debugSourceMethod }}
   {{ end }}
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"


### PR DESCRIPTION
diag: Test explicit 'assets/' prefix for SCSS resources.Get

This commit is a further diagnostic step to address the persistent "can't evaluate field Sass in type interface {}" error during Hugo builds.

It modifies the SCSS processing logic in `layouts/partials/head.html` and `layouts/products/single.html` to test a more explicit path with `resources.Get`.

1.  **Path Change for `resources.Get`:**
    *   The initial attempt to fetch the SCSS file now uses `resources.Get "assets/scss/style.scss"` instead of just `"scss/style.scss"`. This is to test if explicitly including the `assets/` prefix influences how Hugo resolves the resource.

2.  **"Re-Get" and Debugging Logic Retained:**
    *   The extensive "re-get" logic (checking if `resources.Get` returns a string, trimming potential leading slashes, attempting `resources.Match` as a fallback) and detailed `warnf` statements are still in place.
    *   This will allow observation of whether the explicit "assets/" path results in `resources.Get` returning a proper Resource object directly, or if it still returns a string path.

The SCSS processing pipeline remains simplified (no Minify/Fingerprint) for diagnostic clarity. The goal is to see if this path change affects the type of object returned by `resources.Get` and ultimately allows `resources.Sass` to process the file correctly.

Output:
I've made a change to help diagnose the "can't evaluate field Sass in type interface {}" error you've been seeing during Hugo builds.

This involves modifying the SCSS processing logic in `layouts/partials/head.html` and `layouts/products/single.html` to test a more explicit path with `resources.Get`.

Here's what I did:

1.  **Path Change for `resources.Get`:**
    *   I've updated the initial attempt to fetch the SCSS file to use `resources.Get "assets/scss/style.scss"` instead of just `"scss/style.scss"`. I'm doing this to see if explicitly including the `assets/` prefix influences how Hugo resolves the resource.

2.  **"Re-Get" and Debugging Logic Retained:**
    *   I've kept the extensive "re-get" logic (checking if `resources.Get` returns a string, trimming potential leading slashes, attempting `resources.Match` as a fallback) and detailed `warnf` statements in place.
    *   This will help us observe whether the explicit "assets/" path results in `resources.Get` returning a proper Resource object directly, or if it still returns a string path.

The SCSS processing pipeline remains simplified (no Minify/Fingerprint) for diagnostic clarity. My goal here is to see if this path change affects the type of object returned by `resources.Get` and ultimately allows `resources.Sass` to process the file correctly.