### PR TITLE
This commit reverts the `$scssPathKey` used in `resources.Get` back t…

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,7 +17,7 @@
   {{ end }}
 
   {{ "<!-- Main Stylesheet -->" | safeHTML }}
-  {{ $scssPathKey := "assets/scss/style.scss" }} {{/* CHANGED THIS LINE */}}
+  {{ $scssPathKey := "scss/style.scss" }}
   {{ $scssOptions := (dict "outputStyle" "compressed") }}
   {{ $stylesheet := "" }} {{/* Initialize */}}
 

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -53,7 +53,7 @@
   {{ template "_internal/google_analytics.html" . }}
 
   {{/* ─────── 3) Chargement des CSS : Vex, Bootstrap, puis ton CSS perso ─────── */}}
-  {{ $scssPathKey := "assets/scss/style.scss" }} {{/* CHANGED THIS LINE */}}
+  {{ $scssPathKey := "scss/style.scss" }}
   {{ $scssOptions := (dict "outputStyle" "compressed") }}
   {{ $stylesheet := "" }} {{/* Initialize */}}
 


### PR DESCRIPTION
…o "scss/style.scss" (from "assets/scss/style.scss") in both `layouts/partials/head.html` and `layouts/products/single.html`.

The previous build log showed that `resources.Get "assets/scss/style.scss"` returned NIL, indicating that path was incorrect. The original path "scss/style.scss" was the one that resulted in `resources.Get` returning a string path, which is the behavior we are trying to diagnose and handle.

The extensive diagnostic and fallback logic implemented in previous steps is retained:
- Initial `resources.Get "scss/style.scss"`.
- If a string is returned:
    - Log the string.
    - Trim a leading slash if present.
    - Attempt `resources.Match` with the corrected string path.
- Log details about the resource obtained (type, name, etc.) and the method used.
- Attempt `resources.Sass` only if a valid, non-string, non-empty resource is ultimately obtained.

This change, combined with you addressing the separate Netlify secrets scanning issue, aims to either resolve the SCSS processing error or provide definitive logs about the nature of the resource object Hugo is working with for "scss/style.scss".