### PR TITLE
Optimize: Reduce Netlify build time by preventing Python compilation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
 [build.environment]
   HUGO_VERSION = "0.145.0"
   HUGO_BASEURL = "/"
+  MISE_PYTHON_COMPILE = "0"
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
- I'll set MISE_PYTHON_COMPILE = "0" in netlify.toml to instruct mise (Netlify's build tool manager) to use precompiled Python versions instead of compiling Python from source.
- This addresses the issue of a lengthy (2+ minutes) Python 3.13.5 compilation phase during Netlify builds.
- My analysis of build logs confirmed that Netlify's default `mise` setup was attempting to compile Python, and `mise` itself suggested this environment variable as a solution.
- I advised you on testing the performance impact of this change.