### PR TITLE
Feat: Add defensive logging for missing product IDs

### DIFF
--- a/netlify/functions/create-order.js
+++ b/netlify/functions/create-order.js
@@ -51,6 +51,10 @@ async function handleCreateOrder(body) {
   const invoiceLines = [];
 
   for (const product of cart) {
+    if (!product.id) {
+      console.error(`❌ критическая ошибка: ID продукта отсутствует в элементе корзины. Невозможно получить информацию о продукте из Dolibarr. Элемент корзины: ${JSON.stringify(product)}`);
+      // Laisser la fonction continuer ; l'appel axios suivant échouera probablement et sera géré par le try-catch global.
+    }
     const res = await axios.get(`${dolibarrAPI}/products/${product.id}`, { headers });
     const prodData = res.data;
 

--- a/netlify/functions/create-payment.js
+++ b/netlify/functions/create-payment.js
@@ -20,6 +20,17 @@ exports.handler = async function (event) {
     const body = JSON.parse(event.body);
     const { nom, prenom, email, tel, adresse, amount, cart } = body;
 
+    // Vérification des IDs manquants dans le panier d'entrée avant l'insertion Supabase
+    if (cart && Array.isArray(cart)) {
+      for (const item of cart) {
+        if (!item.id) {
+          console.warn(`⚠️ Внимание: входящий элемент корзины не имеет ID. Элемент: ${JSON.stringify(item)}`);
+        }
+      }
+    } else {
+      console.warn("⚠️ Внимание: panier (cart) является либо отсутствующим, либо не массивом в полученных данных.");
+    }
+
     console.info("🎯 Création de paiement Paymee pour:", nom, prenom);
 
     const PAYMEE_TOKEN = process.env.PAYMEE_TOKEN;


### PR DESCRIPTION
- I added/verified defensive logging in `create-payment.js` to warn if incoming cart items from the client are missing an `id`.
- I added/verified defensive logging in `create-order.js` to log a critical error if a product item is missing an `id` before attempting to fetch details from Dolibarr.

This logging is intended to help diagnose the origin of errors where orders fail due to undefined product IDs when interacting with the Dolibarr API.

This commit follows an investigation into an error you reported after RLS was enabled on the `pending_orders` table. While RLS on `pending_orders` (with service roles bypassing) was found not to be the direct cause of the missing IDs in `create-order.js`'s input, this logging will help trace the data integrity from client to backend.