### PR TITLE
Fix: Normalize product IDs to prevent duplicates in cart

### DIFF
--- a/static/js/cart.js
+++ b/static/js/cart.js
@@ -6,6 +6,10 @@ if (typeof window.CART_JS_INITIALIZED === 'undefined') {
 
   function addToCart(product) {
     const cart = JSON.parse(localStorage.getItem(CART_KEY)) || [];
+    // Trim product.id before comparison or storage
+    if (product.id && typeof product.id === 'string') {
+      product.id = product.id.trim();
+    }
     const existing = cart.find(item => item.id === product.id);
 
     if (existing) {
@@ -44,7 +48,7 @@ if (typeof window.CART_JS_INITIALIZED === 'undefined') {
         e.stopPropagation(); // Empêche la propagation au lien parent <a>
 
         const product = {
-          id: button.dataset.id,
+          id: button.dataset.id ? button.dataset.id.trim() : '',
           name: button.dataset.name,
           price: parseFloat(button.dataset.price),
           image: button.dataset.image || "",
@@ -116,7 +120,7 @@ if (typeof window.CART_JS_INITIALIZED === 'undefined') {
         if (button.dataset.listenerAttached === 'true') return;
         button.dataset.listenerAttached = 'true';
         button.addEventListener("click", () => {
-          const id = button.dataset.id;
+          const id = button.dataset.id ? button.dataset.id.trim() : '';
           const cart = JSON.parse(localStorage.getItem(CART_KEY));
           const item = cart.find(p => p.id === id);
           if (item) item.quantity += 1;
@@ -130,7 +134,7 @@ if (typeof window.CART_JS_INITIALIZED === 'undefined') {
         if (button.dataset.listenerAttached === 'true') return;
         button.dataset.listenerAttached = 'true';
         button.addEventListener("click", () => {
-          const id = button.dataset.id;
+          const id = button.dataset.id ? button.dataset.id.trim() : '';
           let cart = JSON.parse(localStorage.getItem(CART_KEY));
           const item = cart.find(p => p.id === id);
           if (item && item.quantity > 1) {
@@ -148,7 +152,7 @@ if (typeof window.CART_JS_INITIALIZED === 'undefined') {
         if (button.dataset.listenerAttached === 'true') return;
         button.dataset.listenerAttached = 'true';
         button.addEventListener("click", () => {
-          const id = button.dataset.id;
+          const id = button.dataset.id ? button.dataset.id.trim() : '';
           let cart = JSON.parse(localStorage.getItem(CART_KEY));
           cart = cart.filter(p => p.id !== id);
           localStorage.setItem(CART_KEY, JSON.stringify(cart));

--- a/static/js/products_dynamic.js
+++ b/static/js/products_dynamic.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     const res = await fetch("https://cdn.stainedglass.tn/proxy/products.php");
     products = await res.json();
+    console.log(JSON.stringify(products, null, 2));
     if (!Array.isArray(products)) throw new Error("Expected array");
     console.log("✅ Produits chargés :", products);
   } catch (err) {
@@ -19,8 +20,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   // 2) On regroupe par référence de base
   const grouped = {};
   products.forEach(prod => {
+    // Normalize prod.ref and prod.id by trimming whitespace
+    if (prod.ref) prod.ref = prod.ref.trim();
+    if (prod.id) prod.id = prod.id.trim();
+    console.log(`Raw product ref: '${prod.ref}', Raw product id: '${prod.id}'`);
     // Exemple : prod.ref = "Assiette-sidi-red" → baseRef = "Assiette"
-    const baseRef = prod.ref.split('-')[0];
+    const baseRef = prod.ref.split('-')[0].trim(); // Ensure baseRef used for grouping is trimmed.
     if (!grouped[baseRef]) {
       grouped[baseRef] = { base: prod, variants: [] };
     }
@@ -33,21 +38,32 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // 3) On génère le HTML pour chaque groupe
   const htmlPieces = await Promise.all(
-    Object.entries(grouped).map(async ([baseRef, group]) => {
+    Object.entries(grouped).map(async ([baseRefRaw, group]) => {
+      const baseRef   = baseRefRaw.trim(); // Ensure baseRef is trimmed for safety.
       const prod      = group.base;
-      const ref       = prod.ref; // ex: "Assiette_sidi"
+      // prod.ref and prod.id are already trimmed from the products.forEach loop.
+      const ref       = prod.ref; // This is the specific product's ref, already trimmed.
       const price     = parseFloat(prod.price) || 0;
       const stock     = prod.stock_reel !== undefined ? prod.stock_reel : "N/A";
-      const id        = prod.id || prod.ref || ref;
+
+      // elementId for HTML elements like swiper, variants select. Uses baseRef as fallback for grouping logic.
+      // Ensure components are trimmed before use. prod.id and prod.ref are already trimmed.
+      const elementId = prod.id || ref || baseRef;
+
       const label     = prod.label || "Nom inconnu";
       const displayRef= ref.replace(/_/g, " ");
 
-      // URL de l'image
+      // dataIdValue for the button, should be specific to the product, prioritizing prod.id then prod.ref.
+      // prod.id and prod.ref are already trimmed.
+      let dataIdValue = prod.id ? prod.id : ref;
+      if (!dataIdValue) dataIdValue = ''; // Ensure it's a string for data-id, fallback to empty if both are null/undefined
+
+      // URL de l'image (uses the trimmed 'ref')
       const imageUrl = `https://cdn.stainedglass.tn/stainedglass-img-cache/${ref}.jpg`;
 
       // 3.1) Slider Swiper pour la variante de base
       const sliderHTML = `
-        <div class="swiper swiper-${id}">
+        <div class="swiper swiper-${elementId}">
           <div class="swiper-wrapper">
             <div class="swiper-slide">
               <img src="${imageUrl}"
@@ -61,10 +77,16 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       // 3.2) Si variantes, on prépare un <select> pour les choisir
       const variantSelect = group.variants.length ? `
-        <label for="variants-${id}">Variantes&nbsp;:</label>
-        <select id="variants-${id}" class="variant-select" data-base="${ref}">
+        <label for="variants-${elementId}">Variantes&nbsp;:</label>
+        <select id="variants-${elementId}" class="variant-select" data-base="${ref}">
           <option value="${ref}">${displayRef}</option>
           ${group.variants.map(v => {
+            // Assuming v.ref was also trimmed in the initial loop if it's from the same products array
+            // If variants are different objects, they might need trimming here:
+            // const variantRef = v.ref ? v.ref.trim() : '';
+            // const disp = variantRef.replace(/_/g, " ");
+            // return `<option value="${variantRef}">${disp}</option>`;
+            // For now, assume v.ref is clean as it's from the same source `products`
             const disp = v.ref.replace(/_/g, " ");
             return `<option value="${v.ref}">${disp}</option>`;
           }).join("")}
@@ -86,7 +108,7 @@ document.addEventListener("DOMContentLoaded", async () => {
               ${variantSelect}
               <button type="button"
                       class="add-to-cart btn btn-warning mt-3"
-                      data-id="${id}"
+                      data-id="${dataIdValue}"
                       data-name="${ref}"
                       data-price="${price}"
                       data-image="${imageUrl}">


### PR DESCRIPTION
This commit addresses an issue where duplicate entries could appear in the shopping cart and items might not be removable.

The root cause was identified as potential inconsistencies in product IDs, likely due to leading/trailing whitespace in the `id` or `ref` fields sourced from the product data API.

Changes:
- In `static/js/products_dynamic.js`:
    - Added logging for raw product `id` and `ref` values to aid future debugging.
    - Implemented normalization (trimming whitespace) for `prod.id` and `prod.ref` immediately after data fetching.
    - Ensured that the `data-id` attribute on 'Add to Cart' buttons is populated with the trimmed ID.
- In `static/js/cart.js`:
    - Implemented normalization (trimming whitespace) for product IDs when: - A product is added to the cart (`addToCart` function). - An ID is read from `button.dataset.id` for adding to cart. - An ID is read from `button.dataset.id` for cart operations (quantity changes, removal).

These changes ensure that product IDs are consistently handled throughout the cart functionality, preventing duplicate entries caused by whitespace variations and ensuring reliable item removal.