### PR TITLE
docs: Add staff guide for admin live chat and fix date shortcode

### DIFF
--- a/content/admin/live-chat-guide.md
+++ b/content/admin/live-chat-guide.md
@@ -7,7 +7,7 @@ weight: 10
 
 ## Using the Admin Live Chat Panel
 
-**Last Updated:** {{< current_date >}} <!-- Placeholder for current date, Hugo can do this if configured -->
+**Last Updated:** June 14, 2024 <!-- Update manually as needed -->
 
 ### 1. Overview
 


### PR DESCRIPTION
- Creates `content/admin/live-chat-guide.md` with instructions for staff on using the new admin live chat panel.
- Replaces a placeholder date shortcode with a static date to resolve Hugo build error.