### PR TITLE
fix: Correctly include admin-chat.js using Hugo Pipes

### DIFF
--- a/layouts/admin/single.html
+++ b/layouts/admin/single.html
@@ -36,5 +36,12 @@
 </div>
 
 <!-- Include admin-specific JavaScript -->
-<script src="/js/admin-chat.js"></script>
+{{ $adminJS := resources.Get "js/admin-chat.js" }}
+{{ if $adminJS }}
+  {{ $builtAdminJS := $adminJS | js.Build }}
+  <script src="{{ $builtAdminJS.RelPermalink }}"></script>
+{{ else }}
+  <!-- Optional: Log an error or warning if the resource is not found during build -->
+  {{ warnf "admin-chat.js not found in assets/js/" }}
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Updates `layouts/admin/single.html` to process `assets/js/admin-chat.js` via Hugo Pipes (`resources.Get` and `js.Build`). This ensures the script is properly included and executed on the admin live chat page, fixing the issue where buttons were unresponsive.