### PR TITLE
debug: Add DOM element checks and null guard for replyStatusDiv

### DIFF
--- a/assets/js/admin-chat.js
+++ b/assets/js/admin-chat.js
@@ -8,6 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const sendReplyBtn = document.getElementById('sendReplyBtn');
     const replyStatusDiv = document.getElementById('replyStatus');
 
+    console.log('Admin Chat DOM Elements Check:', { userIdInput, loadConversationBtn, chatMessagesDiv, currentChatUserIdSpan, replySection, replyMessageInput, sendReplyBtn, replyStatusDiv });
+
     let currentLoadedUserId = null;
 
     // Function to display messages in the chat area
@@ -103,8 +105,13 @@ document.addEventListener('DOMContentLoaded', () => {
     sendReplyBtn.addEventListener('click', async () => {
         const replyText = replyMessageInput.value.trim();
         if (!currentLoadedUserId) {
-            replyStatusDiv.textContent = 'Error: No user conversation loaded.';
-            replyStatusDiv.className = 'mt-2 text-danger';
+            if (replyStatusDiv) {
+                replyStatusDiv.textContent = 'Error: No user conversation loaded.';
+                replyStatusDiv.className = 'mt-2 text-danger';
+            } else {
+                console.error('replyStatusDiv is null when trying to report no user loaded.');
+                // Optionally, alert('Error: No user conversation loaded. Status display element missing.');
+            }
             return;
         }
         if (!replyText) {


### PR DESCRIPTION
Adds console logging in `admin-chat.js` to check if key DOM elements are found on initialization.
Also adds a null check before attempting to use `replyStatusDiv` when sending a reply with no user loaded, to prevent the "Cannot set properties of null" error and help diagnose if the element is missing.