### PR TITLE
I've attempted to resolve an issue where the current chat user ID was…

### DIFF
--- a/assets/js/admin-chat.js
+++ b/assets/js/admin-chat.js
@@ -2,12 +2,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const userIdInput = document.getElementById('userIdInput');
     const loadConversationBtn = document.getElementById('loadConversationBtn');
     const chatMessagesDiv = document.getElementById('chatMessages');
-    const currentChatUserIdSpan = document.getElementById('currentChatUserIdSpan');
+    const currentChatUserIdSpan = document.getElementById('currentChatUserId_elem');
     const replySection = document.getElementById('replySection');
     const replyMessageInput = document.getElementById('replyMessageInput');
     const sendReplyBtn = document.getElementById('sendReplyBtn');
     const replyStatusDiv = document.getElementById('replyStatus');
 
+    // The variable name currentChatUserIdSpan is kept, but it now points to getElementById('currentChatUserId_elem')
+    // The log object below will correctly show the variable currentChatUserIdSpan and its resolved value.
     console.log('Admin Chat DOM Elements Check:', { userIdInput, loadConversationBtn, chatMessagesDiv, currentChatUserIdSpan, replySection, replyMessageInput, sendReplyBtn, replyStatusDiv });
 
     let currentLoadedUserId = null;

--- a/layouts/admin/single.html
+++ b/layouts/admin/single.html
@@ -18,7 +18,7 @@
     </div>
 
     <div class="col-md-8">
-      <h3>Conversation with <span id="currentChatUserId">-</span></h3>
+      <h3>Conversation with <span id="currentChatUserId_elem">-</span></h3>
       <div id="chatMessages" class="chat-messages-area mb-3 p-3 border rounded" style="height: 400px; overflow-y: auto;">
         <p class="text-muted">Select a User ID to view messages.</p>
         <!-- Messages will be appended here -->


### PR DESCRIPTION
… not displaying correctly.

I've changed the ID of the HTML element responsible for showing the current chat user ID to `currentChatUserId_elem`. This change was made in both the HTML structure and the related JavaScript code. The goal is to eliminate any possibility of hidden character problems with the previous ID that might have been causing `getElementById` to not find the element.