### PR TITLE
feat: Add Netlify Identity Widget script

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -45,4 +45,5 @@
     window.APP_CONFIG = {}; // Initialize to prevent errors
   </script>
   {{ end }}
+<script type="text/javascript" src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>


### PR DESCRIPTION
Includes the Netlify Identity Widget JavaScript in the site's <head>. This is a prerequisite for enabling Netlify Identity and protecting routes like the admin panel.