### PR TITLE
Debug: Expose fetched chat history to window for debugging

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -138,6 +138,7 @@ $(window).on('load', function () {
 
             if (response.ok) {
               const historyMessages = await response.json();
+              window.debugHistoryMessages = historyMessages; // For debugging
               liveChatMessages.empty(); // Clear "Loading history..."
               if (historyMessages && historyMessages.length > 0) {
                 historyMessages.forEach(msg => {


### PR DESCRIPTION
In assets/js/script.js, within the live chat history fetching logic, I've assigned the `historyMessages` array to `window.debugHistoryMessages`.

This allows you to inspect the raw historical data fetched from the server directly in the browser console, aiding in diagnosing issues related to incomplete or incorrectly displayed chat history.