### PR TITLE
Fix: Resolve 403 and CORS errors on OVH

### DIFF
--- a/cdn/.htaccess
+++ b/cdn/.htaccess
@@ -1,15 +1,4 @@
 <IfModule mod_headers.c>
-  # CORS Headers
-  Header set Access-Control-Allow-Origin "https://stainedglass.tn"
-  Header set Access-Control-Allow-Methods "GET, POST, OPTIONS" # POST might not be used by all scripts but is safe
-  Header set Access-Control-Allow-Headers "Content-Type, Authorization" # Added Authorization for potential future use
-
-  # Security Headers
-  Header set X-Content-Type-Options "nosniff"
-  Header set X-Frame-Options "SAMEORIGIN"
-  # Consider adding a Content-Security-Policy header here if specific policies are known
-  # Example: Header set Content-Security-Policy "default-src 'self'; script-src 'none'; object-src 'none';"
+  # This block is intentionally left empty.
+  # Header directives are handled by PHP scripts due to server environment limitations.
 </IfModule>
-
-# Disable directory listing
-Options -Indexes

--- a/cdn/proxy/products.php
+++ b/cdn/proxy/products.php
@@ -3,7 +3,26 @@
 
 require_once __DIR__ . '/config.php';
 
+// --- Set HTTP Headers ---
+// CORS Headers
+header("Access-Control-Allow-Origin: https://stainedglass.tn");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS"); // POST for potential future use
+header("Access-Control-Allow-Headers: Content-Type, Authorization");
+
+// Security Headers
+header("X-Content-Type-Options: nosniff");
+header("X-Frame-Options: SAMEORIGIN");
+
+// Content Type
 header('Content-Type: application/json');
+
+// Handle OPTIONS request for CORS preflight
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    // Optionally, you could also check the Origin here against a whitelist
+    // if Access-Control-Allow-Origin was more dynamic.
+    http_response_code(204); // No Content
+    exit;
+}
 
 // --- Cache Configuration ---
 // Ensure PROXY_CACHE_DIR and PROXY_CACHE_EXPIRATION are defined (they should be in config.php)

--- a/cdn/stainedglass-img-cache/.htaccess
+++ b/cdn/stainedglass-img-cache/.htaccess
@@ -1,14 +1,9 @@
 <IfModule mod_headers.c>
-  # CORS Headers
-  Header set Access-Control-Allow-Origin "https://stainedglass.tn"
-  Header set Access-Control-Allow-Methods "GET, OPTIONS" # Images are typically fetched via GET
-  Header set Access-Control-Allow-Headers "Content-Type"
-
-  # Security Headers
-  Header set X-Content-Type-Options "nosniff"
-  Header set X-Frame-Options "SAMEORIGIN" # Or DENY if images are never framed
-  # Consider adding a Content-Security-Policy header here
-  # Example for images: Header set Content-Security-Policy "default-src 'self'; img-src 'self' data:; script-src 'none'; object-src 'none';"
+  # Header directives removed due to mod_headers unavailability on the server.
+  # For static image files, if CORS is needed and mod_headers is unavailable,
+  # alternative server configurations (e.g., at a higher level if on dedicated/VPS)
+  # or a PHP script to serve images would be required to set these headers.
+  # However, images are often less strict about CORS for direct embedding via <img> tags.
 </IfModule>
 
 # Disable directory listing

--- a/cdn/sync_images.php
+++ b/cdn/sync_images.php
@@ -27,14 +27,24 @@ if ($providedToken !== SYNC_IMAGES_TOKEN) {
 // Autoriser CORS - useful if this script is ever called from a browser admin panel
 // For a cron job or direct CLI execution, this might not be strictly necessary
 // but doesn't harm.
-header("Access-Control-Allow-Origin: *"); // Consider restricting this in production
+
+// --- Set HTTP Headers ---
+// CORS Headers
+header("Access-Control-Allow-Origin: https://stainedglass.tn"); // Restricted to specific origin
 header("Access-Control-Allow-Methods: GET, OPTIONS");
-header("Access-Control-Allow-Headers: Content-Type, Authorization");
+header("Access-Control-Allow-Headers: Content-Type, Authorization"); // Authorization for token, Content-Type for any potential POST body if extended
+
+// Security Headers
+header("X-Content-Type-Options: nosniff");
+header("X-Frame-Options: DENY"); // This script should not be framed
+
+// Content Type
 header("Content-Type: application/json");
 
 // Handle OPTIONS request for CORS preflight
 if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
-    exit(0);
+    http_response_code(204); // No Content
+    exit;
 }
 
 function sync_images($productId = null) {


### PR DESCRIPTION
- Modified `cdn/.htaccess` to remove `Options -Indexes` and problematic header directives, leaving only an empty IfModule block to resolve 403 errors on OVH due to `mod_headers` unavailability.
- Ensured `cdn/stainedglass-img-cache/.htaccess` retains `Options -Indexes` but removes header directives.
- Confirmed CORS and security headers are set directly within `proxy/products.php` and `sync_images.php` using PHP's `header()` function.
- Added handling for OPTIONS preflight requests in PHP scripts.