### PR TITLE
fix: Use API data for single product page

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,6 +10,71 @@
     </div>
   </div>
 </section>
-
-<script src="{{ "js/single-product.js" | relURL }}"></script>
 {{ end }}
+
+<script>
+  document.addEventListener("DOMContentLoaded", async () => {
+    const slug = window.location.pathname.split('/').filter(Boolean).pop();
+    console.log("Parsed slug:", slug);
+    const container = document.getElementById("product-details");
+
+    try {
+      const res = await fetch(`https://dolibarr-middleware.onrender.com/api/v1/products/${slug}`);
+      const product = await res.json();
+      console.log("API Response:", product);
+
+      if (product && product.id) {
+        const { name, long_description, price, images, sku, stock_levels, categories, meta_title, meta_description } = product;
+
+        // Set SEO meta tags
+        document.title = meta_title || name;
+        const metaDesc = document.querySelector('meta[name="description"]');
+        if (metaDesc) {
+            metaDesc.setAttribute('content', meta_description || '');
+        }
+
+        const imageUrl = images?.[0]?.url || 'https://cdn.stainedglass.tn/placeholder.jpg';
+        const categoryName = categories?.[0]?.name || 'Misc';
+        const displayName = sku || name;
+        const totalStock = stock_levels?.reduce((total, level) => total + level.quantity, 0) || 0;
+        const stockDisplay = totalStock > 0 ? 'Add to cart' : 'Sold Out';
+        const isSoldOut = totalStock === 0;
+
+        container.innerHTML = `
+          <div class="col-md-6">
+            <img src="${imageUrl}" class="img-fluid" alt="${name}">
+          </div>
+          <div class="col-md-6">
+            <p class="text-muted">${categoryName}</p>
+            <h1>${displayName}</h1>
+            <h3 class="text-primary">${parseFloat(price).toFixed(2)} DT</h3>
+            <div class="mt-4" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; line-height: 1.6;">
+              ${long_description || ''}
+            </div>
+            <button class="btn btn-warning btn-lg mt-4" ${isSoldOut ? 'disabled' : ''}>
+              ${stockDisplay}
+            </button>
+          </div>
+        `;
+      } else {
+        console.error("Product not found or API response is empty.");
+        container.innerHTML = `
+          <div class="col-12 text-center">
+            <h2>Product not found</h2>
+            <p>The product you are looking for does not exist.</p>
+            <a href="/products" class="btn btn-primary">Back to Products</a>
+          </div>
+        `;
+      }
+    } catch (err) {
+      console.error("Error fetching product details:", err);
+      container.innerHTML = `
+        <div class="col-12 text-center">
+          <h2>Error</h2>
+          <p>There was an error loading the product details.</p>
+          <a href="/products" class="btn btn-primary">Back to Products</a>
+        </div>
+      `;
+    }
+  });
+</script>

--- a/themes/vex-hugo/layouts/products/single.html
+++ b/themes/vex-hugo/layouts/products/single.html
@@ -1,50 +1,15 @@
 {{ define "main" }}
-
 <section class="section">
   <div class="container">
-    <div class="row">
-      <div class="col-md-5 mb-4 mb-md-0">
-        <!-- product image slider -->
-        <div class="product-image-slider">
-          {{ range .Params.images }}
-          <div data-image="{{ . | absURL }}">
-            {{ partial "image.html" (dict "Src" . "Alt" "product-image" "Class" "img-fluid w-100" ) }}
-          </div>
-          {{ end }}
+    <div id="product-details" class="row">
+      <div class="col-12 text-center">
+        <div class="spinner-border" role="status">
+          <span class="sr-only">Loading...</span>
         </div>
-      </div>
-      <div class="col-lg-6 col-md-7 offset-lg-1">
-        <h1 class="mb-4">{{ .Title }}</h1>
-        {{ with .Params.colors }}<p><strong>Colors: </strong>{{ delimit . ", " | title}}</p>{{ end }}
-        {{ with .Params.sizes }}<p><strong>Sizes: </strong>{{ delimit . ", " | title}}</p>{{ end }}
-        <p class="price py-4">{{if .Params.discount_price}}{{site.Params.currency}}{{.Params.discount_price}}{{else}}{{site.Params.currency}}{{.Params.price}}{{end}}
-        {{if .Params.discount_price}}<s class="price">{{site.Params.currency}}{{ .Params.price }}</s>{{end}}
-        </p>
-        {{ if site.Params.snipcart.enable }}
-        <button class="snipcart-add-item btn btn-main mb-5" 
-          data-item-id="{{.Title | urlize}}__{{if .Params.discount_price}}{{.Params.discount_price}}{{else}}{{.Params.price}}{{end}}"
-          data-item-name="{{.Title}}"
-          data-item-image="{{with .Params.Images}} {{range first 1 . }}{{. | absURL}}{{end}}{{end}}"
-          data-item-price="{{if .Params.discount_price}}{{.Params.discount_price}}{{else}}{{.Params.price}}{{end}}" data-item-url="{{.Permalink}}" 
-          {{ if .Params.colors }}
-          data-item-custom1-name="Choose Color"
-          data-item-custom1-options="{{range $index, $element:= .Params.colors}}{{ if eq $index 0 }}{{. | title}}{{ else }}|{{. | title }}{{end}}{{end}}"
-          {{ end }}
-          {{ if .Params.sizes }}
-          data-item-custom2-name="Choose Size"
-          data-item-custom2-options="{{range $index, $element:= .Params.sizes}}{{if eq $index 0}}{{. | title}}{{else}}|{{. | title}}{{end}}{{end}}"
-          {{end}}>{{i18n "add_to_cart"}}
-        </button>
-        {{ else }}
-        {{ with .Params.button_link}}
-        <a class="btn btn-main mb-5" href="{{ . | absURL }}">{{i18n "add_to_cart"}}</a>
-        {{ end }}
-        {{ end }}
-
-        <div class="content">{{.Content}}</div>
       </div>
     </div>
   </div>
 </section>
 
+<script src="{{ "js/single-product.js" | relURL }}"></script>
 {{ end }}


### PR DESCRIPTION
The single product page was not rendering correctly because it was using static data from a markdown file instead of fetching the data from the API.

This commit fixes the issue by replacing the static template with a template that fetches and renders the product data from the API. The JavaScript logic is placed in a separate file, `assets/js/single-product.js`, to ensure it is executed correctly.