### PR TITLE
I've fixed the script path for the single product page.

### DIFF
--- a/themes/vex-hugo/layouts/products/single.html
+++ b/themes/vex-hugo/layouts/products/single.html
@@ -11,5 +11,5 @@
   </div>
 </section>
 
-<script src="{{ "js/single-product.js" | relURL }}"></script>
+<script src="{{ "js/single-product.js" | absURL }}"></script>
 {{ end }}


### PR DESCRIPTION
The single product page wasn't rendering correctly because the server couldn't find the `single-product.js` file. This was due to an incorrect path in the template.

I've fixed the issue by changing the script path from `relURL` to `absURL` in `themes/vex-hugo/layouts/products/single.html`. This ensures that the server can locate the file and the product details can be rendered.